### PR TITLE
Suppress forever logging to /root/.forever

### DIFF
--- a/node-server.sh
+++ b/node-server.sh
@@ -17,7 +17,7 @@ case "$1" in
     echo "* starting node-server * "
     echo "* starting node-server * [`date`]" >> /var/log/node-server.log
     cd /home/$USER/app
-    sudo forever start --workingDir /home/$USER/app -a -o /dev/null -e /home/$USER/nodejs.err.log --killSignal=SIGTERM /home/$USER/app/server.js
+    sudo forever start --workingDir /home/$USER/app -a -l /dev/null -o /dev/null -e /home/$USER/nodejs.err.log --killSignal=SIGTERM /home/$USER/app/server.js
     ;;
   stop)
     echo "* stopping node-server * "


### PR DESCRIPTION
Forever is still logging to /root/.forever even is stdout logging was disabled by -o /dev/null. On my system, this was taking almost the same space as the database itself.